### PR TITLE
Make high-availability more configurable

### DIFF
--- a/flink/templates/_flink_config.tpl
+++ b/flink/templates/_flink_config.tpl
@@ -14,7 +14,6 @@ provide jobmanager.rpc.address to Taskmanagers
     {{- if .Values.taskmanager.memoryFlinkSize }}
     taskmanager.memory.flink.size: {{ .Values.taskmanager.memoryFlinkSize }}
     {{- end }}
-    {{- .Values.flink.params | nindent 4 }}
     {{- if .Values.flink.monitoring.enabled }}
     metrics.reporters: prom
     metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
@@ -44,12 +43,13 @@ provide jobmanager.rpc.address to Taskmanagers
     {{- if .Values.jobmanager.highAvailability.enabled }}
     high-availability: zookeeper
     high-availability.zookeeper.quorum: {{ .Values.jobmanager.highAvailability.zookeeperConnect }}
-    high-availability.zookeeper.path.root: /flink
-    high-availability.cluster-id: /flink
+    high-availability.zookeeper.path.root: {{ .Values.jobmanager.highAvailability.zookeeperRootpath }}
+    high-availability.cluster-id: {{ .Values.jobmanager.highAvailability.clusterId }}
     high-availability.storageDir: {{ .Values.jobmanager.highAvailability.storageDir }}
     high-availability.jobmanager.port: {{ .Values.jobmanager.highAvailability.syncPort }}
     {{- else }}
     jobmanager.rpc.address: {{ include "flink.fullname" . }}-jobmanager
     jobmanager.rpc.port: {{ .Values.jobmanager.ports.rpc }}
     {{- end }}
+    {{- .Values.flink.params | nindent 4 }}
 {{- end -}}

--- a/flink/values.yaml
+++ b/flink/values.yaml
@@ -80,6 +80,8 @@ jobmanager:
     # enabled also will enable zookeeper Dependency
     enabled: false
     zookeeperConnect: zookeeper:2181
+    zookeeperRootPath: /flink
+    clusterId: /flink
     # storageDir for Jobmanagers. DFS expected.
     # Docs - Storage directory (required): JobManager metadata is persisted in the file system storageDir and only a pointer to this state is stored in ZooKeeper
     storageDir:


### PR DESCRIPTION
Make high-availability more configurable

- Add option to make `jobmanager.highAvailability.clusterId` configurable
- Add option to make `jobmanager.highAvailability.zookeeperRootPath` configurabled
- Allow overrides using `flink.params` by expanding those last