### PR TITLE
service accounts names fixed

### DIFF
--- a/flink/templates/_config.tpl
+++ b/flink/templates/_config.tpl
@@ -2,14 +2,14 @@
 ServiceAccount for Jobmanager
 */}}
 {{- define "jobmanager.serviceAccount" -}}
-{{ default "jobmanager" .Values.jobmanager.serviceAccount.name }}
+{{ default ( printf "%s-jobmanager" ( include "flink.fullname" . ) ) .Values.jobmanager.serviceAccount.name }}
 {{- end -}}
 
 {{/*
 ServiceAccount for Taskmanager
 */}}
 {{- define "taskmanager.serviceAccount" -}}
-{{ default "taskmanager" .Values.taskmanager.serviceAccount.name }}
+{{ default ( printf "%s-taskmanager" ( include "flink.fullname" . ) ) .Values.taskmanager.serviceAccount.name }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Hi

Comments in values.yaml lines [187](https://github.com/riskfocus/helm-charts-public/blob/master/flink/values.yaml#L187),[253](https://github.com/riskfocus/helm-charts-public/blob/master/flink/values.yaml#L253) say that service accounts names are "generated using the fullname template", which is not true. This PR fixes it. 