### PR TITLE
fix(flink): taskmanager.extraEnvs check

### DIFF
--- a/flink/templates/taskmanager.yaml
+++ b/flink/templates/taskmanager.yaml
@@ -69,7 +69,7 @@ spec:
           {{- if .Values.extraEnvs }}
           {{- toYaml .Values.extraEnvs | nindent 12 }}
           {{- end }}
-          {{- if .Values.jobmanager.extraEnvs }}
+          {{- if .Values.taskmanager.extraEnvs }}
           {{- toYaml .Values.taskmanager.extraEnvs | nindent 12 }}
           {{- end }}
           envFrom:


### PR DESCRIPTION
Allows Task Manager envs to be defined without also defining them for Job Managers.