### PR TITLE
fix(flink): Make service monitor names unique per cluster

### DIFF
--- a/flink/templates/servicemonitors.yaml
+++ b/flink/templates/servicemonitors.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: 'flink-jobmanager'
+  name: {{ include "flink.fullname" . }}-jobmanager
   labels:
 {{ include "flink.labels" . | indent 4 }}
 {{ toYaml .Values.prometheus.serviceMonitor.selector | indent 4 }}
@@ -28,7 +28,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: 'flink-taskmanager'
+  name: {{ include "flink.fullname" . }}-taskmanager
   labels:
 {{ include "flink.labels" . | indent 4 }}
 {{ toYaml .Values.prometheus.serviceMonitor.selector | indent 4 }}


### PR DESCRIPTION
I noticed this issue when creating a couple of test clusters in the same namespace.

Helm 3 will not install the chart a second time due to the name conflict:

>Unable to continue with install: ServiceMonitor "flink-jobmanager" in namespace "default" exists and cannot be imported into the current release

Helm 2 will create the second cluster but only one set of service monitors will exist (I haven't checked if the first cluster's monitors are overwritten or if the second's are not created). When the second cluster is uninstalled the service monitors are removed, breaking monitoring for the first cluster.

Using the full name stops this from happening and brings the service monitor names in line with other resources.