### PR TITLE
feat(flink): switch to bitnami/zookeeper chart

### DIFF
--- a/flink/README.md
+++ b/flink/README.md
@@ -14,6 +14,12 @@ If you are interested in supporting session/job clusters: https://github.com/Goo
 * Requires at least `v2.0.0-beta.1` version of helm to support
   dependency management with requirements.yaml
 
+If Zookeeper is installed by this chart then the follow pre-requisites apply:
+
+* Kubernetes 1.12+
+
+* Helm 3.1.0  
+
 ## StatefulSet Details
 
 * https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
@@ -72,11 +78,10 @@ following configurable parameters(other parameters can be found in values.yaml):
 | `taskmanager.resources`                  | Taskmanager resources                                                                                                                                                    | `{}`                   |
 | `zookeeper.enabled`                      | If True, installs Zookeeper Chart                                                                                                                                        | `false`                |
 | `zookeeper.resources`                    | Zookeeper resource requests and limits                                                                                                                                   | `{}`                   |
-| `zookeeper.env`                          | Environmental variables provided to Zookeeper Zookeeper                                                                                                                  | `{ZK_HEAP_SIZE: "1G"}` |
-| `zookeeper.storage`                      | Zookeeper Persistent volume size                                                                                                                                         | `2Gi`                  |
-| `zookeeper.image.PullPolicy`             | Zookeeper Container pull policy                                                                                                                                          | `IfNotPresent`         |
-| `zookeeper.url`                          | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart)                                                                                                        | `""`                   |
-| `zookeeper.port`                         | Port of Zookeeper Cluster                                                                                                                                                | `2181`                 |
+| `zookeeper.heapSize`                     | Zookeeper heap size                                                                                                                                                      | `1024`                 |
+| `zookeeper.service.port`                 | Zookeeper port number                                                                                                                                                    | `2181`               |      
+| `zookeeper.persistence.size`             | Zookeeper Persistent volume size                                                                                                                                         | `8Gi`                  |
+| `zookeeper.image.pullPolicy`             | Zookeeper Container pull policy                                                                                                                                          | `IfNotPresent`         |
 | `zookeeper.affinity`                     | Defines affinities and anti-affinities for pods as defined in: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity preferences | `{}`                   |
 | `zookeeper.nodeSelector`                 | Node labels for pod assignment                                                                                                                                           | `{}`                   |
 | `secrets.bitnamiSealedSecrets.enabled`   | Enables creation of [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)                                                                                     | `false`                |

--- a/flink/requirements.yaml
+++ b/flink/requirements.yaml
@@ -1,6 +1,5 @@
 dependencies:
   - name:       "zookeeper"
-    version:    "2.0.0"
-    repository: "https://charts.helm.sh/incubator"
+    version:    "~6.7.0"
+    repository: "https://charts.bitnami.com/bitnami"
     condition:  "zookeeper.enabled"
-

--- a/flink/values.yaml
+++ b/flink/values.yaml
@@ -130,7 +130,7 @@ jobmanager:
   highAvailability:
     # enabled also will enable zookeeper Dependency
     enabled: false
-    zookeeperConnect: "{{ .Release.Name }}-zookeeper:{{ .Values.zookeeper.env.ZOO_PORT }}"
+    zookeeperConnect: "{{ .Release.Name }}-zookeeper:{{ .Values.zookeeper.service.port }}"
     zookeeperRootPath: /flink
     clusterId: /flink
     # storageDir for Jobmanagers. DFS expected.
@@ -295,9 +295,9 @@ prometheus:
 zookeeper:
   enabled: false
   replicaCount: 3
-  env:
-    ZK_HEAP_SIZE: "1G"
-    ZOO_PORT: 2181
+  heapSize: 1024
+  service:
+    port: 2181
   resources:
     limits:
       cpu: 400m


### PR DESCRIPTION
The `incubator/zookeeper` chart is deprecated and has not been updated for Kubernetes 1.16. This PR switches the dependency to the `bitnami/zookeeper` chart which appears to be the best maintained Zookeeper chart on Helm hub.

The `README` has been updated as some configuration had to be changed. Some documentation for Zookeeper that appears out of date has also been changed.

I realise this is significant change, especially to the prerequisites when using the chart to install Zookeeper (not everyone has moved to Helm 3 yet). I believe it's necessary however due to the deprecation in Kubernetes 1.16 of the `apps/v1beta1` api version that the old Zookeeper chart uses for the Statefulset.